### PR TITLE
Support meshes with vertex texture coordinates

### DIFF
--- a/src/GPUBuffer.cpp
+++ b/src/GPUBuffer.cpp
@@ -316,3 +316,9 @@ void GPUBuffer::getPixelData(ObjectAttribute attr, float *data) {
     glReadPixels(0, 0, fbo.getWidth(), fbo.getHeight(), GL_DEPTH_COMPONENT, GL_FLOAT, data);
 //    fbo.disableFBO(); */
 }
+
+
+bool GPUBuffer::isTextureAvailable()
+{
+    return this->mesh->texture_coordinates_available;
+}

--- a/src/GPUBuffer.h
+++ b/src/GPUBuffer.h
@@ -42,6 +42,8 @@ public:
 
   void releaseResources();
 
+  bool isTextureAvailable();
+
 private:
 //    static GLSLProgram renderProg;
 //    static FrameBufferObject fbo;

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -22,6 +22,9 @@ struct Geometry {
   // Optional texture
   Texture texture;
 
+  // Texture coordinates flag
+  bool texture_coordinates_available = false;
+
   glm::vec3 boxMin, boxMax;
 
   void calculateAABB() {

--- a/src/PlyLoader.cpp
+++ b/src/PlyLoader.cpp
@@ -65,6 +65,19 @@ int PlyLoader::normal_cb(p_ply_argument arg) {
 }
 
 
+int PlyLoader::texture_cb(p_ply_argument arg) {
+  PlyLoader *self;
+  long coordIndex, vertIndex;
+  ply_get_argument_user_data(arg, reinterpret_cast<void **>(&self), &coordIndex);
+  self->hasVertexTexture = true;
+  ply_get_argument_element(arg, nullptr, &vertIndex);
+
+  self->geo->texcoords[vertIndex][coordIndex] = static_cast<float>(ply_get_argument_value(arg));
+
+  return 1;
+}
+
+
 int PlyLoader::face_texcoord_cb(p_ply_argument arg) {
   PlyLoader *self;
   long length, valIndex, faceIndex;
@@ -132,6 +145,8 @@ bool PlyLoader::loadFile(std::string filename) {
   long numVerts = 0;
   long numFaces = 0;;
 
+  hasVertexTexture = false;
+
   numVerts = ply_set_read_cb(ply, "vertex", "x", vertex_cb, this, 0);
   ply_set_read_cb(ply, "vertex", "y", vertex_cb, this, 1);
   ply_set_read_cb(ply, "vertex", "z", vertex_cb, this, 2);
@@ -143,6 +158,9 @@ bool PlyLoader::loadFile(std::string filename) {
   ply_set_read_cb(ply, "vertex", "nx", normal_cb, this, 0);
   ply_set_read_cb(ply, "vertex", "ny", normal_cb, this, 1);
   ply_set_read_cb(ply, "vertex", "nz", normal_cb, this, 2);
+
+  ply_set_read_cb(ply, "vertex", "texture_u", texture_cb, this, 0);
+  ply_set_read_cb(ply, "vertex", "texture_v", texture_cb, this, 1);
 
   geo->vertices.resize(numVerts);
   geo->colors.resize(numVerts, glm::vec3(0.5f));

--- a/src/PlyLoader.cpp
+++ b/src/PlyLoader.cpp
@@ -192,9 +192,16 @@ bool PlyLoader::loadFile(std::string filename) {
     if (!loadTexture())
       return false;
   }
-  if (hasFaceTexture) {
-//        std::cout << "Converting face texture coordinates to vertex coordinates" << std::endl;
+  // If vertex texture coordinates are not available, try to obtain them from face texture coordinates
+  if (!hasVertexTexture && hasFaceTexture) {
+       // std::cout << "Converting face texture coordinates to vertex coordinates" << std::endl;
     faceTexCoordsToVertexTexCoords();
+  }
+  if (hasVertexTexture || hasFaceTexture) {
+      geo->texture_coordinates_available = true;
+  }
+  else {
+      std::cout << "Warning: mesh " << this->filename << " does not contain texture coordinates." << std::endl;
   }
   if (geo->indexList.empty()) {
 //        std::cout << "Generating index list" << std::endl;

--- a/src/PlyLoader.h
+++ b/src/PlyLoader.h
@@ -13,11 +13,13 @@ public:
   bool loadFile(std::string filename);
 
 private:
-  bool hasNormals, hasFaceTexture;
+  bool hasNormals, hasFaceTexture, hasVertexTexture;
 
   static int vertex_cb(p_ply_argument arg);
 
   static int normal_cb(p_ply_argument arg);
+
+  static int texture_cb(p_ply_argument arg);
 
   static int face_cb(p_ply_argument arg);
 

--- a/src/PythonWrapper.cpp
+++ b/src/PythonWrapper.cpp
@@ -62,7 +62,11 @@ void PythonWrapper::renderObject(unsigned int handle,
 
 py::array PythonWrapper::getColorImage(unsigned int handle) {
 
-  float *buffData = renderer.getBuffer(handle, OA_COLORS);
+  float *buffData;
+  if (renderer.isTextureAvailable(handle))
+    buffData = renderer.getBuffer(handle, OA_TEXTURED);
+  else
+    buffData = renderer.getBuffer(handle, OA_COLORS);
 
   int height = renderer.getHeight();
   int width = renderer.getWidth();

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -333,3 +333,9 @@ void Renderer::saveImage(unsigned int handle, ObjectAttribute attr,
     return;
   }
 }
+
+
+bool Renderer::isTextureAvailable(unsigned int objId)
+{
+    return renderers[objId]->isTextureAvailable();
+}

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -76,6 +76,8 @@ public:
   void saveImage(unsigned int handle, ObjectAttribute attr, int height, int width, int objectID,
                  const std::string &filename);
 
+  bool isTextureAvailable(unsigned int objId);
+
 private:
   Context context;
   int width, height;


### PR DESCRIPTION
This PR enables rendering of meshes with texture.

At the moment, the library only loads meshes having face texture coordinates and completely discard vertex texture coordinates that might available within the mesh.

Secondly, even if the textured render is generated it is not available since the output channel of the shader, i.e. `OA_COLORS`, is hardcoded in

https://github.com/thodan/bop_renderer/blob/451b2affce6d387c8986ced1ebda8c6228ff6058/src/PythonWrapper.cpp#L65

while `OA_TEXTURED` is required to access the textured rendering. As a result, the library can only be used to generate rendering with vertex colors but not with a texture.

I changed this behavior in a way such that the renderer uses `OA_COLORS` and, in case the texture coordinates were loaded correctly, it uses `OA_TEXTURED` for the output of `PythonWrapper::getColorImage()`.

