### PR TITLE
Update CMake & setup CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Build
         run: cmake --build build
       - name: test
-        run: PYTHONPATH=build python samples/renderer_test.py
+        run: PYTHONPATH=build python -c "import bop_renderer"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Check build
+
+on: ["push", "pull_request"]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install -qy python-is-python3 python3-numpy cmake libosmesa6-dev
+      - name: Configure
+        run: cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build
+      - name: test
+        run: PYTHONPATH=build python samples/renderer_test.py

--- a/CMake/FindOSMesa.cmake
+++ b/CMake/FindOSMesa.cmake
@@ -1,0 +1,59 @@
+# Try to find Mesa off-screen library and include dir.
+# Once done this will define
+#
+# OSMesa_FOUND        - true if OSMesa has been found
+# OSMesa_INCLUDE_DIRS - where the GL/osmesa.h can be found
+# OSMesa_LIBRARIES    - Link this to use OSMesa
+# OSMesa_VERSION      - Version of OSMesa found
+# OSMesa::OSMesa      - Imported target
+
+# downloaded from https://gitlab.kitware.com/vtk/vtk/-/blob/master/CMake/FindOSMesa.cmake,  BSD-3-Clause
+
+
+find_path(OSMESA_INCLUDE_DIR
+  NAMES GL/osmesa.h
+  PATHS "${OSMESA_ROOT}/include"
+        "$ENV{OSMESA_ROOT}/include"
+        /usr/openwin/share/include
+        /opt/graphics/OpenGL/include
+  DOC   "OSMesa include directory")
+mark_as_advanced(OSMESA_INCLUDE_DIR)
+
+find_library(OSMESA_LIBRARY
+  NAMES OSMesa OSMesa16 OSMesa32
+  PATHS "${OSMESA_ROOT}/lib"
+        "$ENV{OSMESA_ROOT}/lib"
+        /opt/graphics/OpenGL/lib
+        /usr/openwin/lib
+  DOC   "OSMesa library")
+mark_as_advanced(OSMESA_LIBRARY)
+
+if (OSMESA_INCLUDE_DIR AND EXISTS "${OSMESA_INCLUDE_DIR}/GL/osmesa.h")
+  file(STRINGS "${OSMESA_INCLUDE_DIR}/GL/osmesa.h" _OSMesa_version_lines
+    REGEX "OSMESA_[A-Z]+_VERSION")
+  string(REGEX REPLACE ".*# *define +OSMESA_MAJOR_VERSION +([0-9]+).*" "\\1" _OSMesa_version_major "${_OSMesa_version_lines}")
+  string(REGEX REPLACE ".*# *define +OSMESA_MINOR_VERSION +([0-9]+).*" "\\1" _OSMesa_version_minor "${_OSMesa_version_lines}")
+  string(REGEX REPLACE ".*# *define +OSMESA_PATCH_VERSION +([0-9]+).*" "\\1" _OSMesa_version_patch "${_OSMesa_version_lines}")
+  set(OSMesa_VERSION "${_OSMesa_version_major}.${_OSMesa_version_minor}.${_OSMesa_version_patch}")
+  unset(_OSMesa_version_major)
+  unset(_OSMesa_version_minor)
+  unset(_OSMesa_version_patch)
+  unset(_OSMesa_version_lines)
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OSMesa
+  REQUIRED_VARS OSMESA_INCLUDE_DIR OSMESA_LIBRARY
+  VERSION_VAR OSMesa_VERSION)
+
+if (OSMesa_FOUND)
+  set(OSMesa_INCLUDE_DIRS "${OSMESA_INCLUDE_DIR}")
+  set(OSMesa_LIBRARIES "${OSMESA_LIBRARY}")
+
+  if (NOT TARGET OSMesa::OSMesa)
+    add_library(OSMesa::OSMesa UNKNOWN IMPORTED)
+    set_target_properties(OSMesa::OSMesa PROPERTIES
+      IMPORTED_LOCATION "${OSMESA_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${OSMESA_INCLUDE_DIR}")
+  endif ()
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,42 +1,12 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(bop_renderer)
+cmake_minimum_required(VERSION 3.16)
+project(bop_renderer LANGUAGES C CXX)
 
+set(CMAKE_MODULE_PATH CMake $CMAKE_MODULE_PATH)
 
-################################################################################
-# Before running cmake, set the following environment variables:
+find_package(Python COMPONENTS Interpreter Development)
+find_package(OSMesa REQUIRED)
 
-# OSMESA_PREFIX - Folder with the OSMesa installation
-# PYTHON_PREFIX - Folder with "lib" and "include" subfolders with Python sources
-
-# Example:
-# export OSMESA_PREFIX=/opt/osmesa
-# export PYTHON_PREFIX=~/.conda/envs/env_name
-################################################################################
-
-
-# Enable support for C++11.
-set(CPP_STANDARD -std=c++11)
-add_definitions(${CPP_STANDARD})
-
-# Python library (tested with Python 3.6).
-set(PYTHON_LIBRARIES $ENV{PYTHON_PREFIX}/lib/libpython3.6m.so)
-
-# Directory with Python includes (tested with Python 3.6).
-set(PYTHON_INCLUDE_DIRS $ENV{PYTHON_PREFIX}/include/python3.6m)
-
-# OSMesa.
-set(OSMESA_LIBRARIES $ENV{OSMESA_PREFIX}/lib/libOSMesa32.so)
-include_directories($ENV{OSMESA_PREFIX}/include)
-
-# Pybind11.
-set(PYBIND11_CPP_STANDARD ${CPP_STANDARD})
-set(PYBIND11_PYTHON_VERSION 3.6)
 add_subdirectory(3rd/pybind11)
-
-# Others.
-include_directories(src)
-include_directories(3rd)
-include_directories(3rd/glm)
 
 # Header files.
 set(HEADERFILES
@@ -73,4 +43,6 @@ set(SOURCEFILES
 # Python module.
 pybind11_add_module(bop_renderer MODULE
         src/PythonWrapper.cpp ${HEADERFILES} ${SOURCEFILES})
-target_link_libraries(bop_renderer PRIVATE ${OSMESA_LIBRARIES})
+
+target_link_libraries(bop_renderer PRIVATE OSMesa::OSMesa)
+target_include_directories(bop_renderer PRIVATE src 3rd 3rd/glm)

--- a/README.md
+++ b/README.md
@@ -18,24 +18,16 @@ cd osmesa-install/build
 ../osmesa-install.sh
 ```
 
+On Debian/Ubuntu systems, this is also available through `sudo apt install libosmesa6-dev`.
+
 Moreover, the BOP renderer depends on the following header-only libraries, which are provided in folder *3rd* (no installation is required for these libraries): [glm](https://glm.g-truc.net/0.9.9/index.html), [lodepng](https://lodev.org/lodepng/), [pybind11](https://github.com/pybind/pybind11), [RPly](http://w3.impa.br/~diego/software/rply/).
 
 ### Compilation
 
-In *CMakeLists.txt*, set the following paths:
-```
-set(LLVM_DIR ...)
-set(OSMESA_DIR ...)
-set(PYTHON_LIBRARIES ...)
-set(PYTHON_INCLUDE_DIRS ...)
-```
-
 Compile by:
 ```
-mkdir build
-cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release
-make
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+cmake --build build
 ```
 
 Note: The BOP renderer was tested on Linux only.


### PR DESCRIPTION
Hi,

This PR update the CMake packaging of the project, to automatically find python and OSMesa without the need for the user to set paths in the CMakeLists.txt.
It also un-hardcode the "3.6" version of python.

OSMesa is found thanks to https://gitlab.kitware.com/vtk/vtk/-/blob/master/CMake/FindOSMesa.cmake, which is under BSD-3-Clause license.

The README is also updated for those changes, and a hint about the `libosmesa6-dev` Debian/Ubuntu package is added.

Finally, those changes are tested with a Github Actions job. This only try to import the python lib at the moment, because the scripts in samples/ require bop_toolkit_lib.